### PR TITLE
feat: better support umbrella

### DIFF
--- a/elixirsrc/lib/mix_project.ex
+++ b/elixirsrc/lib/mix_project.ex
@@ -10,11 +10,16 @@ defmodule Snyk.MixProject.Mix.Project do
     lock_file_name = get_lock_file_name(manifest[:lockfile])
     lock_file_path = Path.join(path, lock_file_name)
     lock_file = read_file(lock_file_path)
+    parent_umbrella_manifest = case Path.dirname(lock_file_path) do
+      ^path -> nil
+      parent_path -> load_manifest(parent_path, "parent_app")
+    end
 
     %{
       manifest: manifest,
       lock: lock_file,
-      apps: apps
+      apps: apps,
+      parent_umbrella_manifest: parent_umbrella_manifest
     }
   end
 
@@ -29,9 +34,13 @@ defmodule Snyk.MixProject.Mix.Project do
 
   defp load_manifest(path), do: load_manifest(path, "root_app")
   defp load_manifest(path, app) do
-    Mix.Project.in_project(String.to_atom(app), path, fn module ->
-      module.project ++ [module_name: inspect(module)]
-    end)
+    Mix.Project.in_project(
+      String.to_atom(app),
+      path,
+      fn module ->
+        module.project ++ [module_name: inspect(module)]
+      end
+    )
   end
 
   defp get_apps(nil, _), do: nil

--- a/lib/inspect.ts
+++ b/lib/inspect.ts
@@ -6,6 +6,7 @@ interface Options {
   debug?: boolean;
   dev?: boolean;
   file?: string;
+  allProjects?: boolean; // if true, will not resolve apps if tested manifest is an umbrella project
 }
 
 const PLUGIN_NAME = 'snyk-hex-plugin';
@@ -27,10 +28,10 @@ export async function inspect(
   targetFile: string,
   options: Options = {},
 ): Promise<MultiProjectResult> {
-  const { debug, dev } = options;
+  const { debug, dev, allProjects } = options;
 
   const [scanResult, pluginVersion] = await Promise.all([
-    scan({ debug, dev, path: root, targetFile }),
+    scan({ debug, dev, allProjects, path: root, targetFile }),
     getPluginVersion(),
   ]);
 

--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'upath';
 import * as fs from 'fs';
 import { buildDepGraphs, MixJsonResult } from '@snyk/mix-parser';
 import * as subProcess from './sub-process';
@@ -8,6 +8,7 @@ import { debug, init } from './debug';
 interface Options {
   debug?: boolean; // true will print out debug messages when using the "--debug" flag
   dev?: boolean; // will include dependencies that are limited to non :prod environments
+  allProjects?: boolean; // if true, will not resolve apps if tested manifest is an umbrella project
   projectName?: string; // will be the value of the '--project-name' flag if used.
   path: string;
   targetFile?: string;
@@ -31,7 +32,12 @@ export async function scan(options: Options): Promise<PluginResponse> {
 
   const mixResult = await getMixResult(targetFile.dir);
 
-  const depGraphMap = buildDepGraphs(mixResult, !!options.dev, true);
+  const depGraphMap = buildDepGraphs(
+    mixResult,
+    !!options.dev,
+    true,
+    options.allProjects,
+  );
   const scanResults = Object.entries(depGraphMap).map(([name, depGraph]) => {
     const isRoot = name === 'root';
     return {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/mix-parser": "^1.1.1",
     "debug": "^4.3.1",
-    "tslib": "^2.0.0"
+    "tslib": "^2.0.0",
+    "upath": "2.0.1"
   },
   "devDependencies": {
     "@types/debug": "^4.1.5",

--- a/test/__snapshots__/inspect.test.ts.snap
+++ b/test/__snapshots__/inspect.test.ts.snap
@@ -469,9 +469,48 @@ Object {
 }
 `;
 
-exports[`inspect umbrella/apps/api: length 1`] = `1`;
+exports[`inspect umbrella, allProjects = true: length 1`] = `1`;
 
-exports[`inspect umbrella/apps/api: mix.exs 1`] = `
+exports[`inspect umbrella, allProjects = true: mix.exs 1`] = `
+Object {
+  "depGraph": Object {
+    "graph": Object {
+      "nodes": Array [
+        Object {
+          "deps": Array [],
+          "nodeId": "root-node",
+          "pkgId": "sampleapp@0.0.0",
+        },
+      ],
+      "rootNodeId": "root-node",
+    },
+    "pkgManager": Object {
+      "name": "hex",
+    },
+    "pkgs": Array [
+      Object {
+        "id": "sampleapp@0.0.0",
+        "info": Object {
+          "name": "sampleapp",
+          "version": "0.0.0",
+        },
+      },
+    ],
+    "schemaVersion": "1.2.0",
+  },
+  "packageManager": "hex",
+  "targetFile": "mix.exs",
+}
+`;
+
+exports[`inspect umbrella, allProjects = true: plugin 1`] = `
+Object {
+  "name": "snyk-hex-plugin",
+  "targetFile": "mix.exs",
+}
+`;
+
+exports[`inspect umbrella/apps/api: apps/api/mix.exs 1`] = `
 Object {
   "depGraph": Object {
     "graph": Object {
@@ -489,7 +528,7 @@ Object {
             },
           ],
           "nodeId": "root-node",
-          "pkgId": "api@0.1.0",
+          "pkgId": "sampleapp/apps/api@0.1.0",
         },
         Object {
           "deps": Array [],
@@ -617,9 +656,9 @@ Object {
     },
     "pkgs": Array [
       Object {
-        "id": "api@0.1.0",
+        "id": "sampleapp/apps/api@0.1.0",
         "info": Object {
-          "name": "api",
+          "name": "sampleapp/apps/api",
           "version": "0.1.0",
         },
       },
@@ -690,9 +729,11 @@ Object {
     "schemaVersion": "1.2.0",
   },
   "packageManager": "hex",
-  "targetFile": "mix.exs",
+  "targetFile": "apps/api/mix.exs",
 }
 `;
+
+exports[`inspect umbrella/apps/api: length 1`] = `1`;
 
 exports[`inspect umbrella/apps/api: plugin 1`] = `
 Object {

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -1,5 +1,5 @@
 import { inspect } from '../lib';
-import * as path from 'path';
+import * as path from 'upath';
 import { cleanTargetFile } from './utils';
 import { ScannedProject } from '../lib/inspect';
 
@@ -7,18 +7,19 @@ describe('inspect', () => {
   verifyFixture('simple');
   verifyFixture('umbrella');
   verifyFixture('umbrella/apps/api');
+  verifyFixture('umbrella', true);
 });
 
-function verifyFixture(fixtureName: string) {
-  it(fixtureName, async () => {
+function verifyFixture(fixtureName: string, allProjects = false) {
+  it(`${fixtureName}${allProjects ? ', allProjects = true' : ''}`, async () => {
     const result = await inspect(
       path.resolve(__dirname, `fixtures/${fixtureName}`),
       'mix.exs',
-      { dev: true },
+      { dev: true, allProjects },
     );
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       plugin: { runtime, ...plugin },
       scannedProjects,
     } = result;

--- a/test/scan.missing-tools.test.ts
+++ b/test/scan.missing-tools.test.ts
@@ -1,7 +1,7 @@
 import { mocked } from 'ts-jest/utils';
 
 import { scan } from '../lib';
-import * as path from 'path';
+import * as path from 'upath';
 
 import { execute } from '../lib/sub-process';
 jest.mock('../lib/sub-process', () => {

--- a/test/scan.test.ts
+++ b/test/scan.test.ts
@@ -1,5 +1,5 @@
 import { scan } from '../lib';
-import * as path from 'path';
+import * as path from 'upath';
 import { ScanResult } from '../lib/types';
 import { cleanTargetFile } from './utils';
 

--- a/test/utils.ts
+++ b/test/utils.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'upath';
 
 export function cleanTargetFile(targetFile: string) {
   // This replace will replace windows "\\" with "/" to match snapshot


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

feat: better support umbrella

If the tested manifest s an umbrella app, set the root package name as `UMBRELLA_NAME/apps/NAME` (same as if it was tested through the umbrella manifest)

Add support for 'allProjects' property
If set to true and the tested manifest is an umbrella project, don't test apps (as they will be tested separately)