### PR TITLE
fix: umbrella app targetfile name

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -38,27 +38,29 @@ export async function scan(options: Options): Promise<PluginResponse> {
     true,
     options.allProjects,
   );
-  const scanResults = Object.entries(depGraphMap).map(([name, depGraph]) => {
-    const isRoot = name === 'root';
-    return {
-      identity: {
-        type: 'hex',
-        targetFile: normalizePath(
-          path.relative(
-            options.path,
-            path.resolve(targetFile.dir, isRoot ? '' : name, targetFile.base),
+  const scanResults = Object.entries(depGraphMap).map(
+    ([name, depGraph], index) => {
+      const isRoot = index === 0;
+      return {
+        identity: {
+          type: 'hex',
+          targetFile: normalizePath(
+            path.relative(
+              options.path,
+              path.resolve(targetFile.dir, isRoot ? '' : name, targetFile.base),
+            ),
           ),
-        ),
-      },
-      facts: [
-        {
-          type: 'depGraph',
-          data: depGraph,
         },
-      ],
-      ...(isRoot && options.projectName ? { name: options.projectName } : {}),
-    };
-  });
+        facts: [
+          {
+            type: 'depGraph',
+            data: depGraph,
+          },
+        ],
+        ...(isRoot && options.projectName ? { name: options.projectName } : {}),
+      };
+    },
+  );
 
   return { scanResults };
 }

--- a/test/__snapshots__/inspect.test.ts.snap
+++ b/test/__snapshots__/inspect.test.ts.snap
@@ -510,7 +510,7 @@ Object {
 }
 `;
 
-exports[`inspect umbrella/apps/api: apps/api/mix.exs 1`] = `
+exports[`inspect umbrella/apps/api/mix.exs, allProjects = true: apps/api/mix.exs 1`] = `
 Object {
   "depGraph": Object {
     "graph": Object {
@@ -733,7 +733,239 @@ Object {
 }
 `;
 
+exports[`inspect umbrella/apps/api/mix.exs, allProjects = true: length 1`] = `1`;
+
+exports[`inspect umbrella/apps/api/mix.exs, allProjects = true: plugin 1`] = `
+Object {
+  "name": "snyk-hex-plugin",
+  "targetFile": "mix.exs",
+}
+`;
+
 exports[`inspect umbrella/apps/api: length 1`] = `1`;
+
+exports[`inspect umbrella/apps/api: mix.exs 1`] = `
+Object {
+  "depGraph": Object {
+    "graph": Object {
+      "nodes": Array [
+        Object {
+          "deps": Array [
+            Object {
+              "nodeId": "core@in_umbrella",
+            },
+            Object {
+              "nodeId": "cowboy@1.1.2",
+            },
+            Object {
+              "nodeId": "phoenix@1.3.4",
+            },
+          ],
+          "nodeId": "root-node",
+          "pkgId": "sampleapp/apps/api@0.1.0",
+        },
+        Object {
+          "deps": Array [],
+          "info": Object {
+            "labels": Object {
+              "missingLockFileEntry": "true",
+              "scope": "prod",
+            },
+          },
+          "nodeId": "core@in_umbrella",
+          "pkgId": "core@in_umbrella",
+        },
+        Object {
+          "deps": Array [
+            Object {
+              "nodeId": "cowlib@1.0.2",
+            },
+            Object {
+              "nodeId": "ranch@1.3.2",
+            },
+          ],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "cowboy@1.1.2",
+          "pkgId": "cowboy@1.1.2",
+        },
+        Object {
+          "deps": Array [
+            Object {
+              "nodeId": "cowboy@1.1.2",
+            },
+            Object {
+              "nodeId": "phoenix_pubsub@1.1.0",
+            },
+            Object {
+              "nodeId": "plug@1.6.3",
+            },
+            Object {
+              "nodeId": "poison@3.1.0",
+            },
+          ],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "phoenix@1.3.4",
+          "pkgId": "phoenix@1.3.4",
+        },
+        Object {
+          "deps": Array [],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "cowlib@1.0.2",
+          "pkgId": "cowlib@1.0.2",
+        },
+        Object {
+          "deps": Array [],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "ranch@1.3.2",
+          "pkgId": "ranch@1.3.2",
+        },
+        Object {
+          "deps": Array [],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "phoenix_pubsub@1.1.0",
+          "pkgId": "phoenix_pubsub@1.1.0",
+        },
+        Object {
+          "deps": Array [
+            Object {
+              "nodeId": "cowboy@1.1.2",
+            },
+            Object {
+              "nodeId": "mime@1.3.0",
+            },
+          ],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "plug@1.6.3",
+          "pkgId": "plug@1.6.3",
+        },
+        Object {
+          "deps": Array [],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "poison@3.1.0",
+          "pkgId": "poison@3.1.0",
+        },
+        Object {
+          "deps": Array [],
+          "info": Object {
+            "labels": Object {
+              "scope": "prod",
+            },
+          },
+          "nodeId": "mime@1.3.0",
+          "pkgId": "mime@1.3.0",
+        },
+      ],
+      "rootNodeId": "root-node",
+    },
+    "pkgManager": Object {
+      "name": "hex",
+    },
+    "pkgs": Array [
+      Object {
+        "id": "sampleapp/apps/api@0.1.0",
+        "info": Object {
+          "name": "sampleapp/apps/api",
+          "version": "0.1.0",
+        },
+      },
+      Object {
+        "id": "core@in_umbrella",
+        "info": Object {
+          "name": "core",
+          "version": "in_umbrella",
+        },
+      },
+      Object {
+        "id": "cowboy@1.1.2",
+        "info": Object {
+          "name": "cowboy",
+          "version": "1.1.2",
+        },
+      },
+      Object {
+        "id": "phoenix@1.3.4",
+        "info": Object {
+          "name": "phoenix",
+          "version": "1.3.4",
+        },
+      },
+      Object {
+        "id": "cowlib@1.0.2",
+        "info": Object {
+          "name": "cowlib",
+          "version": "1.0.2",
+        },
+      },
+      Object {
+        "id": "ranch@1.3.2",
+        "info": Object {
+          "name": "ranch",
+          "version": "1.3.2",
+        },
+      },
+      Object {
+        "id": "phoenix_pubsub@1.1.0",
+        "info": Object {
+          "name": "phoenix_pubsub",
+          "version": "1.1.0",
+        },
+      },
+      Object {
+        "id": "plug@1.6.3",
+        "info": Object {
+          "name": "plug",
+          "version": "1.6.3",
+        },
+      },
+      Object {
+        "id": "poison@3.1.0",
+        "info": Object {
+          "name": "poison",
+          "version": "3.1.0",
+        },
+      },
+      Object {
+        "id": "mime@1.3.0",
+        "info": Object {
+          "name": "mime",
+          "version": "1.3.0",
+        },
+      },
+    ],
+    "schemaVersion": "1.2.0",
+  },
+  "packageManager": "hex",
+  "targetFile": "mix.exs",
+}
+`;
 
 exports[`inspect umbrella/apps/api: plugin 1`] = `
 Object {

--- a/test/inspect.test.ts
+++ b/test/inspect.test.ts
@@ -7,14 +7,21 @@ describe('inspect', () => {
   verifyFixture('simple');
   verifyFixture('umbrella');
   verifyFixture('umbrella/apps/api');
-  verifyFixture('umbrella', true);
+  verifyFixture('umbrella', 'mix.exs', true);
+  verifyFixture('umbrella', 'apps/api/mix.exs', true);
 });
 
-function verifyFixture(fixtureName: string, allProjects = false) {
-  it(`${fixtureName}${allProjects ? ', allProjects = true' : ''}`, async () => {
+function verifyFixture(
+  fixtureName: string,
+  targetFile = 'mix.exs',
+  allProjects = false,
+) {
+  it(`${fixtureName}${targetFile === 'mix.exs' ? '' : '/' + targetFile}${
+    allProjects ? ', allProjects = true' : ''
+  }`, async () => {
     const result = await inspect(
       path.resolve(__dirname, `fixtures/${fixtureName}`),
-      'mix.exs',
+      targetFile,
       { dev: true, allProjects },
     );
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Makes the result of a `snyk monitor --all-projects /PATH_TO_UMBRELLA_APP` equals to the result of `snyk monitor /PATH_TO_UMBRELLA_APP`

Today if we monitor an app inside an umbrella app we'll get a different name for the project
This change makes the result of such scenario be the same.
