### PR TITLE
fix/homebrew support

### DIFF
--- a/lib/copy-elixir-code-to-temp-dir.ts
+++ b/lib/copy-elixir-code-to-temp-dir.ts
@@ -1,0 +1,78 @@
+// This file was mostly copied from snyk-python-plugin and its purpose it to support the homebrew package
+import * as fs from 'fs';
+import * as path from 'upath';
+import * as tmp from 'tmp';
+
+export function copyElixirCodeToTempDir(): tmp.DirResult {
+  const tmpDir = tmp.dirSync({ unsafeCleanup: true });
+
+  dumpAllFilesInTempDir(tmpDir.name);
+
+  return tmpDir;
+}
+
+function dumpAllFilesInTempDir(tempDirName: string) {
+  createAssets().forEach((currentReadFilePath) => {
+    if (!fs.existsSync(currentReadFilePath)) {
+      throw new Error('The file `' + currentReadFilePath + '` is missing');
+    }
+
+    const relFilePathToDumpDir = getFilePathRelativeToDumpDir(
+      currentReadFilePath,
+    );
+
+    const writeFilePath = path.join(tempDirName, relFilePathToDumpDir);
+
+    const contents = fs.readFileSync(currentReadFilePath, 'utf8');
+    writeFile(writeFilePath, contents);
+  });
+}
+
+function createAssets() {
+  return [
+    path.join(__dirname, '../elixirsrc/mix.exs'),
+    path.join(__dirname, '../elixirsrc/mix.lock'),
+    path.join(__dirname, '../elixirsrc/lib/mix/tasks/read.mix.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/mix.exs'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/encoder.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/logger.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/decoder.ex'),
+    path.join(
+      __dirname,
+      '../elixirsrc/lib/json/lib/json/encoder/default_implementations.ex',
+    ),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/encoder/errors.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/encoder/helpers.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/parser/number.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/parser/object.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/parser/unicode.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/parser/string.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/parser/array.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json/parser.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/lib/json.ex'),
+    path.join(__dirname, '../elixirsrc/lib/json/.formatter.exs'),
+    path.join(__dirname, '../elixirsrc/lib/common.ex'),
+    path.join(__dirname, '../elixirsrc/lib/mix_project.ex'),
+  ];
+}
+
+function getFilePathRelativeToDumpDir(filePath: string) {
+  let pathParts = filePath.split('\\elixirsrc\\');
+
+  // Windows
+  if (pathParts.length > 1) {
+    return pathParts[1];
+  }
+
+  // Unix
+  pathParts = filePath.split('/elixirsrc/');
+  return pathParts[1];
+}
+
+function writeFile(writeFilePath: string, contents: string) {
+  const dirPath = path.dirname(writeFilePath);
+  if (!fs.existsSync(dirPath)) {
+    fs.mkdirSync(dirPath, { recursive: true });
+  }
+  fs.writeFileSync(writeFilePath, contents);
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/mix-parser": "^1.1.1",
     "debug": "^4.3.1",
+    "tmp": "^0.0.33",
     "tslib": "^2.0.0",
     "upath": "2.0.1"
   },
@@ -40,6 +41,7 @@
     "@types/debug": "^4.1.5",
     "@types/jest": "^25.2.3",
     "@types/node": "^10.17.55",
+    "@types/tmp": "^0.1.0",
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "eslint": "^7.0.0",


### PR DESCRIPTION
### What this does

Instead of assuming elixir code exists in the plugin folder, copy it to a temp dir and run it from there.
This is required for the homebrew version of the snyk cli