### PR TITLE
fix: package-name flag naming fix

### DIFF
--- a/lib/scan.ts
+++ b/lib/scan.ts
@@ -129,6 +129,6 @@ function getRelativePathToManifest(
 function getProjectNamePath(options: Options, relativePathToManifest: string) {
   return [
     options.projectName,
-    ...relativePathToManifest.split('/').slice(1, -1),
+    ...relativePathToManifest.split('/').slice(0, -1),
   ].join('/');
 }

--- a/test/__snapshots__/inspect.test.ts.snap
+++ b/test/__snapshots__/inspect.test.ts.snap
@@ -1245,7 +1245,7 @@ Object {
     "schemaVersion": "1.2.0",
   },
   "meta": Object {
-    "projectName": "renamed-package/api",
+    "projectName": "renamed-package/apps/api",
   },
   "packageManager": "hex",
   "targetFile": "apps/api/mix.exs",
@@ -1507,7 +1507,7 @@ Object {
     "schemaVersion": "1.2.0",
   },
   "meta": Object {
-    "projectName": "renamed-package/core",
+    "projectName": "renamed-package/apps/core",
   },
   "packageManager": "hex",
   "targetFile": "apps/core/mix.exs",

--- a/test/__snapshots__/scan.test.ts.snap
+++ b/test/__snapshots__/scan.test.ts.snap
@@ -1787,7 +1787,7 @@ Object {
     "targetFile": "apps/api/mix.exs",
     "type": "hex",
   },
-  "name": "renamed-project/api",
+  "name": "renamed-project/apps/api",
 }
 `;
 
@@ -2054,7 +2054,7 @@ Object {
     "targetFile": "apps/core/mix.exs",
     "type": "hex",
   },
-  "name": "renamed-project/core",
+  "name": "renamed-project/apps/core",
 }
 `;
 


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes project naming when using the `--project-name` feature in umbrella projects:
Without the feature it's `umbrella-name/apps/app-name`
With the feature it's `new-project-name/app-name`

This PR changes it to `new-project-name/apps/app-name`