### PR TITLE
Chore/fix lint and windows tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,14 @@ commands:
         default: ""
     steps:
       - run:
+          name: Installing Scoop
+          command: iex "& {$(irm get.scoop.sh)} -RunAsAdmin"
+      - run:
+          name: Installing Erlang
+          command: scoop install erlang@24.3.4.4
+      - run:
           name: Installing Elixir
-          command: choco install elixir --version << parameters.elixir_version >> -y
+          command: scoop install elixir@<< parameters.elixir_version >>
   setup_snyk_user:
     steps:
       - run:
@@ -175,7 +181,7 @@ workflows:
           matrix:
             parameters:
               node_version: [ "10.24", "12.21" ]
-              elixir_version: [ "1.13.3"]
+              elixir_version: [ "1.11", "1.10", "1.9"]
 
       # Release
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@5.0.0
+  win: circleci/windows@2.4.0
 
 defaults: &defaults
   parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  win: circleci/windows@2.4.0
+  win: circleci/windows@5.0.0
 
 defaults: &defaults
   parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,7 +175,7 @@ workflows:
           matrix:
             parameters:
               node_version: [ "10.24", "12.21" ]
-              elixir_version: [ "1.11.2", "1.10.3", "1.9.4"]
+              elixir_version: [ "1.13.3"]
 
       # Release
       - release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ commands:
     steps:
       - run:
           name: Installing Elixir
-          command: choco install elixir --version << parameters.elixir_version >> --allow-downgrade
+          command: choco install elixir --version << parameters.elixir_version >> -y
   setup_snyk_user:
     steps:
       - run:

--- a/lib/copy-elixir-code-to-temp-dir.ts
+++ b/lib/copy-elixir-code-to-temp-dir.ts
@@ -17,9 +17,8 @@ function dumpAllFilesInTempDir(tempDirName: string) {
       throw new Error('The file `' + currentReadFilePath + '` is missing');
     }
 
-    const relFilePathToDumpDir = getFilePathRelativeToDumpDir(
-      currentReadFilePath,
-    );
+    const relFilePathToDumpDir =
+      getFilePathRelativeToDumpDir(currentReadFilePath);
 
     const writeFilePath = path.join(tempDirName, relFilePathToDumpDir);
 

--- a/package.json
+++ b/package.json
@@ -47,10 +47,10 @@
     "eslint": "^7.0.0",
     "eslint-config-prettier": "^6.11.0",
     "jest": "^26.0.1",
-    "prettier": "^2.0.5",
+    "prettier": "^2.7.1",
     "ts-jest": "^26.0.0",
     "ts-node": "^8.10.1",
     "tsc-watch": "^4.2.7",
-    "typescript": "^3.9.3"
+    "typescript": "^4.2.0"
   }
 }

--- a/test/scan.missing-tools.test.ts
+++ b/test/scan.missing-tools.test.ts
@@ -37,22 +37,24 @@ type ExecutionMockFunction = (
   args: string[],
 ) => Promise<string>;
 
-const getMockedExecutionFunction = (
-  mixOutcome: MockOutcome,
-  generalOutcome: MockOutcome,
-): ExecutionMockFunction => (command: string, args: string[]) => {
-  const getOutcomePromise = (outcome: MockOutcome) => {
-    return outcome === 'reject'
-      ? Promise.reject('Error')
-      : Promise.resolve('Success');
+const getMockedExecutionFunction =
+  (
+    mixOutcome: MockOutcome,
+    generalOutcome: MockOutcome,
+  ): ExecutionMockFunction =>
+  (command: string, args: string[]) => {
+    const getOutcomePromise = (outcome: MockOutcome) => {
+      return outcome === 'reject'
+        ? Promise.reject('Error')
+        : Promise.resolve('Success');
+    };
+
+    if (command === 'mix' && args[0] === '-v') {
+      return getOutcomePromise(mixOutcome);
+    }
+
+    return getOutcomePromise(generalOutcome);
   };
-
-  if (command === 'mix' && args[0] === '-v') {
-    return getOutcomePromise(mixOutcome);
-  }
-
-  return getOutcomePromise(generalOutcome);
-};
 
 function runFixture(fixtureName: string, options?: any) {
   return scan({


### PR DESCRIPTION
This PR fixes the linting issue and the broken windows test.

When choco installed elixir with the desirable versions, the installation result were broken for some reason. 1.13.3 can be installed successfully (https://community.chocolatey.org/packages/Elixir) but it has compatibility issue with erlang OTP25 as it was compiled with erlang OTP22.

It seems that erlang OTP24 has better compatibility with different older versions of elixir.