### PR TITLE
fix: quote spawn args

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,5 +1,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.13.5
-ignore: {}
-# patches apply the minimum changes required to fix a vulnerability
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  'snyk:lic:npm:shescape:MPL-2.0':
+    - '*':
+        reason: None Given
+        expires: 2122-12-29T08:08:41.608Z
+        created: 2022-11-29T08:08:41.611Z
 patch: {}

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -1,5 +1,6 @@
 import * as childProcess from 'child_process';
 import { debug } from './debug';
+import { quoteAll } from 'shescape';
 
 export function execute(
   command: string,
@@ -12,6 +13,7 @@ export function execute(
   if (options && options.cwd) {
     spawnOptions.cwd = options.cwd;
   }
+  args = quoteAll(args, spawnOptions);
 
   return new Promise((resolve, reject) => {
     let stdout = '';

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@snyk/dep-graph": "^1.28.0",
     "@snyk/mix-parser": "^1.1.1",
     "debug": "^4.3.1",
+    "shescape": "1.6.1",
     "tmp": "^0.0.33",
     "tslib": "^2.0.0",
     "upath": "2.0.1"


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Escape child process arguments