### PR TITLE
Fix/elixir 1.19 json namespace collision

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -207,7 +207,7 @@ workflows:
           matrix:
             parameters:
               node_version: [ "20.19.1", "22.15.1", "24.1.0" ]
-              elixir_version: [ "1.18-erlang-27.2.2" ]
+              elixir_version: [ "1.18-erlang-27.2.2", "1.19-erlang-27.2.2" ]
       - test-windows:
           name: Windows with node v<< matrix.node_version >>, elixir v<< matrix.elixir_version >>
           context: nodejs-install
@@ -216,7 +216,7 @@ workflows:
           matrix:
             parameters:
               node_version: [ "20.19.1", "22.15.1", "24.1.0" ]
-              elixir_version: [ "1.18.2" ]
+              elixir_version: [ "1.18.2", "1.19.5" ]
 
       # Release
       - release:

--- a/elixirsrc/lib/common.ex
+++ b/elixirsrc/lib/common.ex
@@ -5,7 +5,7 @@ defmodule Snyk.MixProject.Common do
       {:error, error_msg} -> error(error_msg)
     end
 
-    IO.binwrite(file, JSON.encode!(content))
+    IO.binwrite(file, Snyk.JSON.encode!(content))
   end
 
   def error(msg) do
@@ -14,7 +14,7 @@ defmodule Snyk.MixProject.Common do
   end
 end
 
-defimpl JSON.Encoder, for: Regex do
+defimpl Snyk.JSON.Encoder, for: Regex do
   def encode(_), do: {:ok, "\"regex\""}
 
   def typeof(_), do: :string

--- a/elixirsrc/lib/json/lib/json.ex
+++ b/elixirsrc/lib/json/lib/json.ex
@@ -1,53 +1,53 @@
-defmodule JSON do
+defmodule Snyk.JSON do
   @moduledoc """
-  Provides a RFC 7159, ECMA 404, and JSONTestSuite compliant JSON Encoder / Decoder
+  Provides a RFC 7159, ECMA 404, and JSONTestSuite compliant Snyk.JSON Encoder / Decoder
   """
 
   require Logger
 
-  import JSON.Logger
+  import Snyk.JSON.Logger
 
-  alias JSON.Decoder
-  alias JSON.Encoder
+  alias Snyk.JSON.Decoder
+  alias Snyk.JSON.Encoder
 
   @vsn "1.0.2"
 
   @doc """
-  Returns a JSON string representation of the Elixir term
+  Returns a Snyk.JSON string representation of the Elixir term
 
   ## Examples
 
-      iex> JSON.encode([result: "this will be a JSON result"])
-      {:ok, "{\\\"result\\\":\\\"this will be a JSON result\\\"}"}
+      iex> Snyk.JSON.encode([result: "this will be a Snyk.JSON result"])
+      {:ok, "{\\\"result\\\":\\\"this will be a Snyk.JSON result\\\"}"}
 
   """
   @spec encode(term) :: {atom, bitstring}
   defdelegate encode(term), to: Encoder
 
   @doc """
-  Returns a JSON string representation of the Elixir term, raises errors when something bad happens
+  Returns a Snyk.JSON string representation of the Elixir term, raises errors when something bad happens
 
   ## Examples
 
-      iex> JSON.encode!([result: "this will be a JSON result"])
-      "{\\\"result\\\":\\\"this will be a JSON result\\\"}"
+      iex> Snyk.JSON.encode!([result: "this will be a Snyk.JSON result"])
+      "{\\\"result\\\":\\\"this will be a Snyk.JSON result\\\"}"
 
   """
   @spec encode!(term) :: bitstring
   def encode!(term) do
     case encode(term) do
       {:ok, value} -> value
-      {:error, error_info} -> raise JSON.Encoder.Error, error_info: error_info
-      _ -> raise JSON.Encoder.Error
+      {:error, error_info} -> raise Snyk.JSON.Encoder.Error, error_info: error_info
+      _ -> raise Snyk.JSON.Encoder.Error
     end
   end
 
   @doc """
-  Converts a valid JSON string into an Elixir term
+  Converts a valid Snyk.JSON string into an Elixir term
 
   ## Examples
 
-      iex> JSON.decode("{\\\"result\\\":\\\"this will be an Elixir result\\\"}")
+      iex> Snyk.JSON.decode("{\\\"result\\\":\\\"this will be an Elixir result\\\"}")
       {:ok, Enum.into([{"result", "this will be an Elixir result"}], Map.new)}
   """
   @spec decode(bitstring) :: {atom, term}
@@ -55,11 +55,11 @@ defmodule JSON do
   defdelegate decode(bitstring_or_char_list), to: Decoder
 
   @doc """
-  Converts a valid JSON string into an Elixir term, raises errors when something bad happens
+  Converts a valid Snyk.JSON string into an Elixir term, raises errors when something bad happens
 
   ## Examples
 
-      iex> JSON.decode!("{\\\"result\\\":\\\"this will be an Elixir result\\\"}")
+      iex> Snyk.JSON.decode!("{\\\"result\\\":\\\"this will be an Elixir result\\\"}")
       Enum.into([{"result", "this will be an Elixir result"}], Map.new)
   """
   @spec decode!(bitstring) :: term
@@ -80,14 +80,14 @@ defmodule JSON do
           "#{__MODULE__}.decode!(#{inspect(bitstring_or_char_list)}} unexpected token #{tok}"
         end)
 
-        raise JSON.Decoder.UnexpectedTokenError, token: tok
+        raise Snyk.JSON.Decoder.UnexpectedTokenError, token: tok
 
       {:error, :unexpected_end_of_buffer} ->
         log(:debug, fn ->
           "#{__MODULE__}.decode!(#{inspect(bitstring_or_char_list)}} end of buffer"
         end)
 
-        raise JSON.Decoder.UnexpectedEndOfBufferError
+        raise Snyk.JSON.Decoder.UnexpectedEndOfBufferError
 
       e ->
         log(:debug, fn ->

--- a/elixirsrc/lib/json/lib/json/decoder.ex
+++ b/elixirsrc/lib/json/lib/json/decoder.ex
@@ -1,6 +1,6 @@
-defprotocol JSON.Decoder do
+defprotocol Snyk.JSON.Decoder do
   @moduledoc """
-  Defines the protocol required for converting raw JSON into Elixir terms
+  Defines the protocol required for converting raw Snyk.JSON into Elixir terms
   """
 
   @doc """
@@ -10,29 +10,29 @@ defprotocol JSON.Decoder do
   def decode(bitstring_or_char_list)
 end
 
-defmodule JSON.Decoder.DefaultImplementations do
+defmodule Snyk.JSON.Decoder.DefaultImplementations do
   require Logger
-  import JSON.Logger
+  import Snyk.JSON.Logger
 
-  defimpl JSON.Decoder, for: BitString do
+  defimpl Snyk.JSON.Decoder, for: BitString do
     @moduledoc """
-    JSON Decoder implementation for BitString values
+    Snyk.JSON Decoder implementation for BitString values
     """
 
-    alias JSON.Parser, as: Parser
+    alias Snyk.JSON.Parser, as: Parser
 
     @doc """
     decodes json in BitString format
 
     ## Examples
 
-        iex> JSON.Decoder.decode ""
+        iex> Snyk.JSON.Decoder.decode ""
         {:error, :unexpected_end_of_buffer}
 
-        iex> JSON.Decoder.decode "face0ff"
+        iex> Snyk.JSON.Decoder.decode "face0ff"
         {:error, {:unexpected_token, "face0ff"}}
 
-        iex> JSON.Decoder.decode "-hello"
+        iex> Snyk.JSON.Decoder.decode "-hello"
         {:error, {:unexpected_token, "-hello"}}
 
     """
@@ -52,7 +52,7 @@ defmodule JSON.Decoder.DefaultImplementations do
 
         {:ok, value, rest} ->
           log(:debug, fn ->
-            "#{__MODULE__}.decode(#{inspect(bitstring)}) trimming remainder of JSON payload #{
+            "#{__MODULE__}.decode(#{inspect(bitstring)}) trimming remainder of Snyk.JSON payload #{
               inspect(rest)
             }..."
           end)
@@ -60,7 +60,7 @@ defmodule JSON.Decoder.DefaultImplementations do
           case rest |> String.trim() do
             <<>> ->
               log(:debug, fn ->
-                "#{__MODULE__}.decode(#{inspect(bitstring)}) successfully trimmed remainder JSON payload!"
+                "#{__MODULE__}.decode(#{inspect(bitstring)}) successfully trimmed remainder Snyk.JSON payload!"
               end)
 
               log(:debug, fn ->
@@ -80,25 +80,25 @@ defmodule JSON.Decoder.DefaultImplementations do
     end
   end
 
-  defimpl JSON.Decoder, for: List do
+  defimpl Snyk.JSON.Decoder, for: List do
     @moduledoc """
-    JSON Decoder implementation for Charlist values
+    Snyk.JSON Decoder implementation for Charlist values
     """
 
-    alias JSON.Decoder, as: Decoder
+    alias Snyk.JSON.Decoder, as: Decoder
 
     @doc """
     decodes json in BitString format
 
     ## Examples
 
-        iex> JSON.Decoder.decode ""
+        iex> Snyk.JSON.Decoder.decode ""
         {:error, :unexpected_end_of_buffer}
 
-        iex> JSON.Decoder.decode "face0ff"
+        iex> Snyk.JSON.Decoder.decode "face0ff"
         {:error, {:unexpected_token, "face0ff"}}
 
-        iex> JSON.Decoder.decode "-hello"
+        iex> Snyk.JSON.Decoder.decode "-hello"
         {:error, {:unexpected_token, "-hello"}}
 
     """

--- a/elixirsrc/lib/json/lib/json/encoder.ex
+++ b/elixirsrc/lib/json/lib/json/encoder.ex
@@ -1,21 +1,21 @@
-defprotocol JSON.Encoder do
+defprotocol Snyk.JSON.Encoder do
   @fallback_to_any true
 
   @moduledoc """
-  Defines the protocol required for converting Elixir types into JSON and inferring their json types.
+  Defines the protocol required for converting Elixir types into Snyk.JSON and inferring their json types.
   """
 
   @doc """
-  Returns a JSON string representation of the Elixir term
+  Returns a Snyk.JSON string representation of the Elixir term
 
   ## Examples
-      iex> JSON.Encoder.encode({1, :two, "three"})
+      iex> Snyk.JSON.Encoder.encode({1, :two, "three"})
       {:ok, "[1,\\\"two\\\",\\\"three\\\"]"}
 
-      iex> JSON.Encoder.encode([result: "this will be a elixir result"])
+      iex> Snyk.JSON.Encoder.encode([result: "this will be a elixir result"])
       {:ok, "{\\\"result\\\":\\\"this will be a elixir result\\\"}"}
 
-      iex> JSON.Encoder.encode(%{a: 1, b: 2})
+      iex> Snyk.JSON.Encoder.encode(%{a: 1, b: 2})
       {:ok, "{\\\"a\\\":1,\\\"b\\\":2}"}
   """
   @spec encode(tuple | HashDict.t() | list | integer | float | map | list | atom | term) ::
@@ -23,25 +23,25 @@ defprotocol JSON.Encoder do
   def encode(term)
 
   @doc """
-  Returns an atom that reprsents the JSON type for the term
+  Returns an atom that reprsents the Snyk.JSON type for the term
 
   ## Examples
-      iex> JSON.Encoder.typeof(3)
+      iex> Snyk.JSON.Encoder.typeof(3)
       :number
 
-      iex> JSON.Encoder.typeof({1, :two, "three"})
+      iex> Snyk.JSON.Encoder.typeof({1, :two, "three"})
       :array
 
-      iex> JSON.Encoder.typeof([foo: "this will be a elixir result"])
+      iex> Snyk.JSON.Encoder.typeof([foo: "this will be a elixir result"])
       :object
 
-      iex> JSON.Encoder.typeof([result: "this will be a elixir result"])
+      iex> Snyk.JSON.Encoder.typeof([result: "this will be a elixir result"])
       :object
 
-      iex> JSON.Encoder.typeof(["this will be a elixir result"])
+      iex> Snyk.JSON.Encoder.typeof(["this will be a elixir result"])
       :array
 
-      iex> JSON.Encoder.typeof([foo: "bar"])
+      iex> Snyk.JSON.Encoder.typeof([foo: "bar"])
       :object
   """
   @spec typeof(term) :: atom

--- a/elixirsrc/lib/json/lib/json/encoder/default_implementations.ex
+++ b/elixirsrc/lib/json/lib/json/encoder/default_implementations.ex
@@ -1,20 +1,20 @@
-defimpl JSON.Encoder, for: Tuple do
+defimpl Snyk.JSON.Encoder, for: Tuple do
   @doc """
-  Encodes an Elixir tuple into a JSON array
+  Encodes an Elixir tuple into a Snyk.JSON array
   """
-  def encode(term), do: term |> Tuple.to_list() |> JSON.Encoder.Helpers.enum_encode()
+  def encode(term), do: term |> Tuple.to_list() |> Snyk.JSON.Encoder.Helpers.enum_encode()
 
   @doc """
-  Returns an atom that represents the JSON type for the term
+  Returns an atom that represents the Snyk.JSON type for the term
   """
   def typeof(_), do: :array
 end
 
-defimpl JSON.Encoder, for: HashDict do
+defimpl Snyk.JSON.Encoder, for: HashDict do
   @doc """
-  Encodes an Elixir HashDict into a JSON object
+  Encodes an Elixir HashDict into a Snyk.JSON object
   """
-  def encode(dict), do: JSON.Encoder.Helpers.dict_encode(dict)
+  def encode(dict), do: Snyk.JSON.Encoder.Helpers.dict_encode(dict)
 
   @doc """
   Returns :object
@@ -22,22 +22,22 @@ defimpl JSON.Encoder, for: HashDict do
   def typeof(_), do: :object
 end
 
-defimpl JSON.Encoder, for: List do
+defimpl Snyk.JSON.Encoder, for: List do
   @doc """
-  Encodes an Elixir List into a JSON array
+  Encodes an Elixir List into a Snyk.JSON array
   """
   def encode([]), do: {:ok, "[]"}
 
   def encode(list) do
     if Keyword.keyword?(list) do
-      JSON.Encoder.Helpers.dict_encode(list)
+      Snyk.JSON.Encoder.Helpers.dict_encode(list)
     else
-      JSON.Encoder.Helpers.enum_encode(list)
+      Snyk.JSON.Encoder.Helpers.enum_encode(list)
     end
   end
 
   @doc """
-  Returns an atom that represents the JSON type for the term
+  Returns an atom that represents the Snyk.JSON type for the term
   """
   def typeof([]), do: :array
 
@@ -50,42 +50,42 @@ defimpl JSON.Encoder, for: List do
   end
 end
 
-defimpl JSON.Encoder, for: [Integer, Float] do
+defimpl Snyk.JSON.Encoder, for: [Integer, Float] do
   @doc """
-  Converts Elixir Integer and Floats into JSON Numbers
+  Converts Elixir Integer and Floats into Snyk.JSON Numbers
   """
   # Elixir converts octal, etc into decimal when putting in strings
   def encode(number), do: {:ok, "#{number}"}
 
   @doc """
-  Returns an atom that represents the JSON type for the term
+  Returns an atom that represents the Snyk.JSON type for the term
   """
   def typeof(_), do: :number
 end
 
-defimpl JSON.Encoder, for: Atom do
+defimpl Snyk.JSON.Encoder, for: Atom do
   @doc """
-  Converts Elixir Atoms into their JSON equivalents
+  Converts Elixir Atoms into their Snyk.JSON equivalents
   """
   def encode(nil), do: {:ok, "null"}
   def encode(false), do: {:ok, "false"}
   def encode(true), do: {:ok, "true"}
-  def encode(atom) when is_atom(atom), do: atom |> Atom.to_string() |> JSON.Encoder.encode()
+  def encode(atom) when is_atom(atom), do: atom |> Atom.to_string() |> Snyk.JSON.Encoder.encode()
 
   @doc """
-  Returns an atom that represents the JSON type for the term
+  Returns an atom that represents the Snyk.JSON type for the term
   """
   def typeof(boolean) when is_boolean(boolean), do: :boolean
   def typeof(nil), do: :null
   def typeof(atom) when is_atom(atom), do: :string
 end
 
-defimpl JSON.Encoder, for: BitString do
+defimpl Snyk.JSON.Encoder, for: BitString do
   # 32 = ascii space, cleaner than using "? ", I think
   @acii_space 32
 
   @doc """
-  Converts Elixir String into JSON String
+  Converts Elixir String into Snyk.JSON String
   """
   def encode(bitstring), do: {:ok, <<?">> <> encode_binary_recursive(bitstring, []) <> <<?">>}
 
@@ -127,53 +127,53 @@ defimpl JSON.Encoder, for: BitString do
   defp zeropad_hexadecimal_unicode_control_character(iolist) when is_list(iolist), do: iolist
 
   @doc """
-  Returns an atom that represents the JSON type for the term
+  Returns an atom that represents the Snyk.JSON type for the term
   """
   def typeof(_), do: :string
 end
 
-defimpl JSON.Encoder, for: Record do
+defimpl Snyk.JSON.Encoder, for: Record do
   @doc """
   Encodes elixir records into json objects
   """
-  def encode(record), do: record.to_keywords |> JSON.Encoder.Helpers.dict_encode()
+  def encode(record), do: record.to_keywords |> Snyk.JSON.Encoder.Helpers.dict_encode()
 
   @doc """
-  Encodes a record into a JSON object
+  Encodes a record into a Snyk.JSON object
   """
   def typeof(_), do: :object
 end
 
-defimpl JSON.Encoder, for: Map do
+defimpl Snyk.JSON.Encoder, for: Map do
   @doc """
   Encodes maps into object
   """
-  def encode(map), do: map |> JSON.Encoder.Helpers.dict_encode()
+  def encode(map), do: map |> Snyk.JSON.Encoder.Helpers.dict_encode()
 
   @doc """
-  Returns an atom that represents the JSON type for the term
+  Returns an atom that represents the Snyk.JSON type for the term
   """
   def typeof(_), do: :object
 end
 
-defimpl JSON.Encoder, for: Any do
+defimpl Snyk.JSON.Encoder, for: Any do
   @moduledoc """
   Falllback module for encoding any other values
   """
 
   @doc """
-  Encodes a map into a JSON object
+  Encodes a map into a Snyk.JSON object
   """
   def encode(%{} = struct) do
     struct
     |> Map.to_list()
-    |> JSON.Encoder.Helpers.dict_encode()
+    |> Snyk.JSON.Encoder.Helpers.dict_encode()
   end
 
   def encode(x) do
     x
     |> Kernel.inspect()
-    |> JSON.Encoder.encode()
+    |> Snyk.JSON.Encoder.encode()
   end
 
   @doc """

--- a/elixirsrc/lib/json/lib/json/encoder/errors.ex
+++ b/elixirsrc/lib/json/lib/json/encoder/errors.ex
@@ -1,30 +1,30 @@
-defmodule JSON.Decoder.Error do
+defmodule Snyk.JSON.Decoder.Error do
   @moduledoc """
   Thrown when an unknown decoder error happens
   """
-  defexception message: "Invalid JSON - unknown error"
+  defexception message: "Invalid Snyk.JSON - unknown error"
 end
 
-defmodule JSON.Decoder.UnexpectedEndOfBufferError do
+defmodule Snyk.JSON.Decoder.UnexpectedEndOfBufferError do
   @moduledoc """
   Thrown when the json payload is incomplete
   """
-  defexception message: "Invalid JSON - unexpected end of buffer"
+  defexception message: "Invalid Snyk.JSON - unexpected end of buffer"
 end
 
-defmodule JSON.Decoder.UnexpectedTokenError do
+defmodule Snyk.JSON.Decoder.UnexpectedTokenError do
   @moduledoc """
   Thrown when the json payload is invalid
   """
   defexception token: nil
 
   @doc """
-    Invalid JSON - Unexpected token
+    Invalid Snyk.JSON - Unexpected token
   """
-  def message(exception), do: "Invalid JSON - unexpected token >>#{exception.token}<<"
+  def message(exception), do: "Invalid Snyk.JSON - unexpected token >>#{exception.token}<<"
 end
 
-defmodule JSON.Encoder.Error do
+defmodule Snyk.JSON.Encoder.Error do
   @moduledoc """
   Thrown when an encoder error happens
   """
@@ -34,7 +34,7 @@ defmodule JSON.Encoder.Error do
     Invalid Term
   """
   def message(exception) do
-    error_message = "An error occurred while encoding the JSON object"
+    error_message = "An error occurred while encoding the Snyk.JSON object"
 
     if nil != exception.error_info do
       error_message <> " >>#{exception.error_info}<<"

--- a/elixirsrc/lib/json/lib/json/encoder/helpers.ex
+++ b/elixirsrc/lib/json/lib/json/encoder/helpers.ex
@@ -1,9 +1,9 @@
-defmodule JSON.Encoder.Helpers do
+defmodule Snyk.JSON.Encoder.Helpers do
   @moduledoc """
-  Helper functions for JSON.Encoder
+  Helper functions for Snyk.JSON.Encoder
   """
 
-  alias JSON.Encoder, as: Encoder
+  alias Snyk.JSON.Encoder, as: Encoder
 
   @doc """
   Given an enumerable encode the enumerable as an array.

--- a/elixirsrc/lib/json/lib/json/logger.ex
+++ b/elixirsrc/lib/json/lib/json/logger.ex
@@ -1,4 +1,4 @@
-defmodule JSON.Logger do
+defmodule Snyk.JSON.Logger do
   @moduledoc """
   Exposes separate log level configuration so developers can set logging
   verbosity for json library
@@ -41,7 +41,7 @@ defmodule JSON.Logger do
   """
   defmacro log(level, message) do
     quote bind_quoted: [level: level, message: message] do
-      if level in JSON.Logger.allowed_levels() do
+      if level in Snyk.JSON.Logger.allowed_levels() do
         Logger.log(level, message)
       else
         :ok

--- a/elixirsrc/lib/json/lib/json/parser.ex
+++ b/elixirsrc/lib/json/lib/json/parser.ex
@@ -1,71 +1,71 @@
-defmodule JSON.Parser do
+defmodule Snyk.JSON.Parser do
   @moduledoc """
-  Implements a JSON Parser for Bitstring values
+  Implements a Snyk.JSON Parser for Bitstring values
   """
 
-  alias JSON.Parser, as: Parser
+  alias Snyk.JSON.Parser, as: Parser
   alias Parser.Array, as: ArrayParser
   alias Parser.Number, as: NumberParser
   alias Parser.Object, as: ObjectParser
   alias Parser.String, as: StringParser
 
   require Logger
-  import JSON.Logger
+  import Snyk.JSON.Logger
 
   @doc """
-  parses a valid JSON value, returns its elixir representation
+  parses a valid Snyk.JSON value, returns its elixir representation
 
   ## Examples
 
-      iex> JSON.Parser.parse ""
+      iex> Snyk.JSON.Parser.parse ""
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.parse "face0ff"
+      iex> Snyk.JSON.Parser.parse "face0ff"
       {:error, {:unexpected_token, "face0ff"}}
 
-      iex> JSON.Parser.parse "-hello"
+      iex> Snyk.JSON.Parser.parse "-hello"
       {:error, {:unexpected_token, "-hello"}}
 
-      iex> JSON.Parser.parse "129245"
+      iex> Snyk.JSON.Parser.parse "129245"
       {:ok, 129245, ""}
 
-      iex> JSON.Parser.parse "7.something"
+      iex> Snyk.JSON.Parser.parse "7.something"
       {:ok, 7, ".something"}
 
-      iex> JSON.Parser.parse "-88.22suffix"
+      iex> Snyk.JSON.Parser.parse "-88.22suffix"
       {:ok, -88.22, "suffix"}
 
-      iex> JSON.Parser.parse "-12e4and then some"
+      iex> Snyk.JSON.Parser.parse "-12e4and then some"
       {:ok, -1.2e+5, "and then some"}
 
-      iex> JSON.Parser.parse "7842490016E-12-and more"
+      iex> Snyk.JSON.Parser.parse "7842490016E-12-and more"
       {:ok, 7.842490016e-3, "-and more"}
 
-      iex> JSON.Parser.parse "null"
+      iex> Snyk.JSON.Parser.parse "null"
       {:ok, nil, ""}
 
-      iex> JSON.Parser.parse "false"
+      iex> Snyk.JSON.Parser.parse "false"
       {:ok, false, ""}
 
-      iex> JSON.Parser.parse "true"
+      iex> Snyk.JSON.Parser.parse "true"
       {:ok, true, ""}
 
-      iex> JSON.Parser.parse "\\\"7.something\\\""
+      iex> Snyk.JSON.Parser.parse "\\\"7.something\\\""
       {:ok, "7.something", ""}
 
-      iex> JSON.Parser.parse "\\\"-88.22suffix\\\" foo bar"
+      iex> Snyk.JSON.Parser.parse "\\\"-88.22suffix\\\" foo bar"
       {:ok, "-88.22suffix", " foo bar"}
 
-      iex> JSON.Parser.parse "\\\"star -> \\\\u272d <- star\\\""
+      iex> Snyk.JSON.Parser.parse "\\\"star -> \\\\u272d <- star\\\""
       {:ok, "star -> ✭ <- star", ""}
 
-      iex> JSON.Parser.parse "[]"
+      iex> Snyk.JSON.Parser.parse "[]"
       {:ok, [], ""}
 
-      iex> JSON.Parser.parse "[\\\"foo\\\", 1, 2, 1.5] lala"
+      iex> Snyk.JSON.Parser.parse "[\\\"foo\\\", 1, 2, 1.5] lala"
       {:ok, ["foo", 1, 2, 1.5], " lala"}
 
-      iex> JSON.Parser.parse "{\\\"result\\\": \\\"this will be a elixir result\\\"} lalal"
+      iex> Snyk.JSON.Parser.parse "{\\\"result\\\": \\\"this will be a elixir result\\\"} lalal"
       {:ok, Enum.into([{"result", "this will be a elixir result"}], Map.new), " lalal"}
   """
 

--- a/elixirsrc/lib/json/lib/json/parser/array.ex
+++ b/elixirsrc/lib/json/lib/json/parser/array.ex
@@ -1,34 +1,34 @@
-defmodule JSON.Parser.Array do
+defmodule Snyk.JSON.Parser.Array do
   @moduledoc """
-  Implements a JSON Array Parser for Bitstring values
+  Implements a Snyk.JSON Array Parser for Bitstring values
   """
 
-  alias JSON.Parser, as: Parser
+  alias Snyk.JSON.Parser, as: Parser
 
   require Logger
-  import JSON.Logger
+  import Snyk.JSON.Logger
 
   @doc """
-  parses a valid JSON array value, returns its elixir list representation
+  parses a valid Snyk.JSON array value, returns its elixir list representation
 
   ## Examples
 
-      iex> JSON.Parser.Array.parse ""
+      iex> Snyk.JSON.Parser.Array.parse ""
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.Array.parse "[1, 2 "
+      iex> Snyk.JSON.Parser.Array.parse "[1, 2 "
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.Array.parse "face0ff"
+      iex> Snyk.JSON.Parser.Array.parse "face0ff"
       {:error, {:unexpected_token, "face0ff"}}
 
-      iex> JSON.Parser.Array.parse "[] lala"
+      iex> Snyk.JSON.Parser.Array.parse "[] lala"
       {:ok, [], " lala"}
 
-      iex> JSON.Parser.Array.parse "[]"
+      iex> Snyk.JSON.Parser.Array.parse "[]"
       {:ok, [], ""}
 
-      iex> JSON.Parser.Array.parse "[\\\"foo\\\", 1, 2, 1.5] lala"
+      iex> Snyk.JSON.Parser.Array.parse "[\\\"foo\\\", 1, 2, 1.5] lala"
       {:ok, ["foo", 1, 2, 1.5], " lala"}
   """
   def parse(<<?[, rest::binary>>) do

--- a/elixirsrc/lib/json/lib/json/parser/number.ex
+++ b/elixirsrc/lib/json/lib/json/parser/number.ex
@@ -1,38 +1,38 @@
-defmodule JSON.Parser.Number do
+defmodule Snyk.JSON.Parser.Number do
   @moduledoc """
-  Implements a JSON Numeber Parser for Bitstring values
+  Implements a Snyk.JSON Numeber Parser for Bitstring values
   """
 
   @doc """
-  parses a valid JSON numerical value, returns its elixir numerical representation
+  parses a valid Snyk.JSON numerical value, returns its elixir numerical representation
 
   ## Examples
 
-      iex> JSON.Parser.Number.parse ""
+      iex> Snyk.JSON.Parser.Number.parse ""
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.Number.parse "face0ff"
+      iex> Snyk.JSON.Parser.Number.parse "face0ff"
       {:error, {:unexpected_token, "face0ff"}}
 
-      iex> JSON.Parser.Number.parse "-hello"
+      iex> Snyk.JSON.Parser.Number.parse "-hello"
       {:error, {:unexpected_token, "hello"}}
 
-      iex> JSON.Parser.Number.parse "129245"
+      iex> Snyk.JSON.Parser.Number.parse "129245"
       {:ok, 129245, ""}
 
-      iex> JSON.Parser.Number.parse "7.something"
+      iex> Snyk.JSON.Parser.Number.parse "7.something"
       {:ok, 7, ".something"}
 
-      iex> JSON.Parser.Number.parse "7.4566something"
+      iex> Snyk.JSON.Parser.Number.parse "7.4566something"
       {:ok, 7.4566, "something"}
 
-      iex> JSON.Parser.Number.parse "-88.22suffix"
+      iex> Snyk.JSON.Parser.Number.parse "-88.22suffix"
       {:ok, -88.22, "suffix"}
 
-      iex> JSON.Parser.Number.parse "-12e4and then some"
+      iex> Snyk.JSON.Parser.Number.parse "-12e4and then some"
       {:ok, -1.2e+5, "and then some"}
 
-      iex> JSON.Parser.Number.parse "7842490016E-12-and more"
+      iex> Snyk.JSON.Parser.Number.parse "7842490016E-12-and more"
       {:ok, 7.842490016e-3, "-and more"}
   """
   def parse(<<?-, rest::binary>>) do

--- a/elixirsrc/lib/json/lib/json/parser/object.ex
+++ b/elixirsrc/lib/json/lib/json/parser/object.ex
@@ -1,31 +1,31 @@
-defmodule JSON.Parser.Object do
+defmodule Snyk.JSON.Parser.Object do
   @moduledoc """
-  Implements a JSON Object Parser for Bitstring values
+  Implements a Snyk.JSON Object Parser for Bitstring values
   """
 
-  alias JSON.Parser, as: Parser
+  alias Snyk.JSON.Parser, as: Parser
 
   @doc """
-  parses a valid JSON object value, returns its elixir representation
+  parses a valid Snyk.JSON object value, returns its elixir representation
 
   ## Examples
 
-      iex> JSON.Parser.Object.parse ""
+      iex> Snyk.JSON.Parser.Object.parse ""
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.Object.parse "face0ff"
+      iex> Snyk.JSON.Parser.Object.parse "face0ff"
       {:error, {:unexpected_token, "face0ff"}}
 
-      iex> JSON.Parser.Object.parse "[] "
+      iex> Snyk.JSON.Parser.Object.parse "[] "
       {:error, {:unexpected_token, "[] "}}
 
-      iex> JSON.Parser.Object.parse "[]"
+      iex> Snyk.JSON.Parser.Object.parse "[]"
       {:error, {:unexpected_token, "[]"}}
 
-      iex> JSON.Parser.Object.parse "[\\\"foo\\\", 1, 2, 1.5] lala"
+      iex> Snyk.JSON.Parser.Object.parse "[\\\"foo\\\", 1, 2, 1.5] lala"
       {:error, {:unexpected_token, "[\\\"foo\\\", 1, 2, 1.5] lala"}}
 
-      iex> JSON.Parser.Object.parse "{\\\"result\\\": \\\"this will be a elixir result\\\"} lalal"
+      iex> Snyk.JSON.Parser.Object.parse "{\\\"result\\\": \\\"this will be a elixir result\\\"} lalal"
       {:ok, Enum.into([{"result", "this will be a elixir result"}], Map.new), " lalal"}
   """
   def parse(<<?{, rest::binary>>) do

--- a/elixirsrc/lib/json/lib/json/parser/string.ex
+++ b/elixirsrc/lib/json/lib/json/parser/string.ex
@@ -1,45 +1,45 @@
-defmodule JSON.Parser.String do
+defmodule Snyk.JSON.Parser.String do
   @moduledoc """
-  Implements a JSON String Parser for Bitstring values
+  Implements a Snyk.JSON String Parser for Bitstring values
   """
 
-  alias JSON.Parser.Unicode, as: UnicodeParser
+  alias Snyk.JSON.Parser.Unicode, as: UnicodeParser
 
   use Bitwise
 
   @doc """
-  parses a valid JSON string, returns its elixir representation
+  parses a valid Snyk.JSON string, returns its elixir representation
 
   ## Examples
 
-      iex> JSON.Parser.String.parse ""
+      iex> Snyk.JSON.Parser.String.parse ""
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.String.parse "face0ff"
+      iex> Snyk.JSON.Parser.String.parse "face0ff"
       {:error, {:unexpected_token, "face0ff"}}
 
-      iex> JSON.Parser.String.parse "-hello"
+      iex> Snyk.JSON.Parser.String.parse "-hello"
       {:error, {:unexpected_token, "-hello"}}
 
-      iex> JSON.Parser.String.parse "129245"
+      iex> Snyk.JSON.Parser.String.parse "129245"
       {:error, {:unexpected_token, "129245"}}
 
-      iex> JSON.Parser.String.parse "\\\"7.something\\\""
+      iex> Snyk.JSON.Parser.String.parse "\\\"7.something\\\""
       {:ok, "7.something", ""}
 
-      iex> JSON.Parser.String.parse "\\\"-88.22suffix\\\" foo bar"
+      iex> Snyk.JSON.Parser.String.parse "\\\"-88.22suffix\\\" foo bar"
       {:ok, "-88.22suffix", " foo bar"}
 
-      iex> JSON.Parser.String.parse "\\\"star -> \\\\u272d <- star\\\""
+      iex> Snyk.JSON.Parser.String.parse "\\\"star -> \\\\u272d <- star\\\""
       {:ok, "star -> ✭ <- star", ""}
 
-      iex> JSON.Parser.String.parse "\\\"\\\\u00df ist wunderbar\\\""
+      iex> Snyk.JSON.Parser.String.parse "\\\"\\\\u00df ist wunderbar\\\""
       {:ok, "ß ist wunderbar", ""}
 
-      iex> JSON.Parser.String.parse "\\\"Rafaëlla\\\" foo bar"
+      iex> Snyk.JSON.Parser.String.parse "\\\"Rafaëlla\\\" foo bar"
       {:ok, "Rafaëlla", " foo bar"}
 
-      iex> JSON.Parser.String.parse "\\\"Éloise woot\\\" Éloise"
+      iex> Snyk.JSON.Parser.String.parse "\\\"Éloise woot\\\" Éloise"
       {:ok, "Éloise woot", " Éloise"}
   """
   def parse(<<?"::utf8, json::binary>>), do: parse_string_contents(json, [])

--- a/elixirsrc/lib/json/lib/json/parser/unicode.ex
+++ b/elixirsrc/lib/json/lib/json/parser/unicode.ex
@@ -1,6 +1,6 @@
-defmodule JSON.Parser.Unicode do
+defmodule Snyk.JSON.Parser.Unicode do
   @moduledoc """
-  Implements a JSON Unicode Parser for Bitstring values
+  Implements a Snyk.JSON Unicode Parser for Bitstring values
   """
 
   use Bitwise
@@ -11,13 +11,13 @@ defmodule JSON.Parser.Unicode do
 
   ## Examples
 
-      iex> JSON.Parser.parse ""
+      iex> Snyk.JSON.Parser.parse ""
       {:error, :unexpected_end_of_buffer}
 
-      iex> JSON.Parser.parse "face0ff"
+      iex> Snyk.JSON.Parser.parse "face0ff"
       {:error, {:unexpected_token, "face0ff"}}
 
-      iex> JSON.Parser.parse "-hello"
+      iex> Snyk.JSON.Parser.parse "-hello"
       {:error, {:unexpected_token, "-hello"}}
 
   """

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -54,7 +54,13 @@ export function execute(
         debug(
           `Error running "${command} ${args.join(' ')}", exit code: ${code}`,
         );
-        return reject(stdout || stderr);
+        debug(`stdout:`, stdout);
+        debug(`stderr:`, stderr);
+        // Reject with BOTH streams. Rejecting with `stdout || stderr` discarded
+        // stderr whenever the child wrote anything to stdout (e.g. Elixir's
+        // "Compiling N files (.ex)" message), which hid the real failure reason
+        // (such as an Elixir stacktrace) from the debug logs.
+        return reject([stdout, stderr].filter(Boolean).join('\n'));
       }
       debug(`Sub process stderr:`, stderr);
       resolve(stdout || stderr);

--- a/test/elixirsrc-namespace.test.ts
+++ b/test/elixirsrc-namespace.test.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs';
+import * as path from 'upath';
+
+function elixirFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...elixirFiles(full));
+    } else if (entry.name.endsWith('.ex')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('elixirsrc vendored namespace', () => {
+  // Regression guard for the Elixir 1.18+ built-in JSON collision.
+  // Elixir 1.18 added a standard-library `JSON` module and `JSON.Encoder`
+  // protocol. The vendored JSON library must therefore stay under the `Snyk.`
+  // namespace so it never shadows the built-ins; a bare `JSON` made
+  // `mix read.mix` crash at runtime with `JSON.Encoder.encode/2 is undefined`.
+  it('does not define a bare top-level JSON module/protocol/impl', () => {
+    const root = path.resolve(__dirname, '..', 'elixirsrc');
+    const offenders = elixirFiles(root).filter((file) =>
+      /\b(defmodule|defprotocol|defimpl)\s+JSON\b/.test(
+        fs.readFileSync(file, 'utf8'),
+      ),
+    );
+
+    expect(offenders.map((f) => path.relative(root, f))).toEqual([]);
+  });
+});

--- a/test/fixtures/subprocess/emit.js
+++ b/test/fixtures/subprocess/emit.js
@@ -1,0 +1,8 @@
+// Test helper for sub-process.test.ts.
+// Writes the given text to stdout and/or stderr, then exits with the given code.
+// Usage: node emit.js <stdoutText> <stderrText> <exitCode>
+// Pass '-' for a stream to write nothing to it.
+const [, , out = '-', err = '-', code = '0'] = process.argv;
+if (out !== '-') process.stdout.write(out);
+if (err !== '-') process.stderr.write(err);
+process.exit(Number(code));

--- a/test/sub-process.test.ts
+++ b/test/sub-process.test.ts
@@ -1,0 +1,32 @@
+import * as path from 'upath';
+import * as subProcess from '../lib/sub-process';
+
+const emit = path.resolve(__dirname, 'fixtures', 'subprocess', 'emit.js');
+
+describe('sub-process execute', () => {
+  it('resolves with stdout on success', async () => {
+    const output = await subProcess.execute('node', [emit, 'hello', '-', '0']);
+    expect(output).toContain('hello');
+  });
+
+  // Regression guard: a non-zero exit must surface stderr even when the child
+  // also wrote to stdout. Previously execute() rejected with `stdout || stderr`,
+  // which dropped stderr whenever stdout was non-empty (e.g. Elixir's
+  // "Compiling N files (.ex)" message), hiding the real failure reason.
+  it('rejects with BOTH stdout and stderr when exit code is non-zero', async () => {
+    const error = await subProcess
+      .execute('node', [emit, 'compiling', 'real-error', '1'])
+      .catch((e) => e as string);
+
+    expect(error).toContain('real-error');
+    expect(error).toContain('compiling');
+  });
+
+  it('rejects with stderr when there is no stdout', async () => {
+    const error = await subProcess
+      .execute('node', [emit, '-', 'only-stderr', '1'])
+      .catch((e) => e as string);
+
+    expect(error).toContain('only-stderr');
+  });
+});


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Fixes Elixir scans failing on **Elixir 1.18+ / OTP 27–28** with:

```
Unspecified Error (SNYK-CLI-0000)
Failed to get dependencies for all 1 potential projects.
  mix.exs: Error parsing manifest file on <project>
```

**Root cause:** the bundled helper encodes its output with `JSON.encode!`
(`elixirsrc/lib/common.ex`) using a vendored `json` library that defines
`defmodule JSON` and a `JSON.Encoder` protocol. **Elixir 1.18 added a built-in
`JSON` module + `JSON.Encoder` protocol**, so on Elixir ≥ 1.18 the two collide.
Compilation only warns (`redefining module JSON`), but at runtime the built-in
`JSON.encode!/2` dispatches to `JSON.Encoder.encode/2` while the loaded protocol
is the vendored one (`encode/1`):

```
** (UndefinedFunctionError) function JSON.Encoder.encode/2 is undefined or private
    (elixir 1.19.5) lib/json.ex:484: JSON.encode!/2
    (snyk 0.1.0)    lib/common.ex:8: Snyk.MixProject.Common.save_to_file/2
    (snyk 0.1.0)    lib/mix/tasks/read.mix.ex:15: Mix.Tasks.Read.Mix.run/1
```

`mix read.mix` exits 1 → the CLI reports the generic "Error parsing manifest
file". The crash is module-load-order dependent (pre-compiling masks it), which
is why it hit users on Elixir 1.19 but slipped through CI (which tested only
Elixir 1.18).

### Changes (4 commits)

1. **fix:** namespace the vendored library `JSON*` → `Snyk.JSON*` so it never
   shadows the stdlib `JSON`. Deterministic across Elixir 1.8 → 1.19+, and keeps
   the offline "compile bundled source" design (no deps fetched at scan time).
2. **fix:** `lib/sub-process.ts` now rejects with **both** stdout and stderr
   (previously `stdout || stderr` discarded stderr whenever the child wrote to
   stdout, hiding the real Elixir error from `-d` logs).
3. **ci:** add Elixir 1.19 to the Unix (`1.19-erlang-27.2.2`) and Windows
   (`1.19.5`) matrices. cimg/elixir has no 1.19 + OTP 28 image, but the bug is
   Elixir-version-driven, so 1.19 on OTP 27 exercises the same path.
4. **test:** `test/sub-process.test.ts` (a non-zero exit must surface stderr,
   not just stdout) and `test/elixirsrc-namespace.test.ts` (version-independent
   guard that no vendored `.ex` defines a bare top-level `JSON*`).

### Notes for the reviewer

Alternatives considered and rejected: using Elixir's built-in `JSON` (drops
< 1.18 support) and switching to Jason (requires fetching a hex dep at scan
time, breaking offline / air-gapped / private-repo scans).

Verified locally on **Elixir 1.19.5 / OTP 28**: `mix read.mix` on the reported
project now exits 0 with valid JSON; `npm test` is green (23/23); `npm run lint`
clean. Both new tests were confirmed to fail when their respective bug is
reintroduced.

