### PR TITLE
fix: add nodejs-install context to the release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,9 @@ workflows:
       # Release
       - release:
           name: Release
-          context: github-release
+          context:
+            - nodejs-install
+            - github-release
           node_version: "24.13.1"
           requires:
             - test-unix


### PR DESCRIPTION
The release job ran with only the `github-release` context, so @semantic-release/npm had no npm registry auth context and aborted at verifyConditions:

    ENONPMTOKEN No npm token specified.

The `nodejs-install` context (already used by the lint, security and test jobs) provides that context. Add it alongside `github-release` on the release job so verifyConditions passes and publishing proceeds via OIDC.