### PR TITLE
chore: transfer ownership to @snyk/engines_sca-scanners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @snyk/open-source_composition-analysis
+* @snyk/engines_sca-scanners


### PR DESCRIPTION
### What?

- `.github/CODEOWNERS`: ownership rules assigning `@snyk/open-source_composition-analysis` move to `@snyk/engines_sca-scanners` (other co-owners on shared lines are unchanged).

### Why?

`@snyk/engines_sca-scanners` now owns this repo, so review requests should land with them rather than the previous team.

---

> [!NOTE]
> **Low Risk**
> Metadata-only ownership update; no runtime or behavior changes.